### PR TITLE
refactor: JWT 토큰에 사용되는 환경변수 변경

### DIFF
--- a/src/main/java/com/snacks/demo/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/snacks/demo/jwt/JwtAuthenticationFilter.java
@@ -82,28 +82,28 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     String refreshToken = JWT.create()
         .withSubject(customUserDetails.getUsername())
         .withExpiresAt(new Date(System.currentTimeMillis() + Long.parseLong(
-            env.getProperty("refresh_token_validation_second"))))
+            env.getProperty("REFRESH_EXPR"))))
         .withClaim("email", customUserDetails.getUsername())
-        .sign(Algorithm.HMAC512(env.getProperty("secret")));
+        .sign(Algorithm.HMAC512(env.getProperty("SECRET_SALT")));
 
     String accessToken = JWT.create()
         .withSubject(customUserDetails.getUsername())
         .withExpiresAt(new Date(System.currentTimeMillis() + Long.parseLong(
-            env.getProperty("access_token_validation_second"))))
+            env.getProperty("ACCESS_EXPR"))))
         .withClaim("email", customUserDetails.getUsername())
-        .sign(Algorithm.HMAC512(env.getProperty("secret")));
+        .sign(Algorithm.HMAC512(env.getProperty("SECRET_SALT")));
 
     redisService.setValues(customUserDetails.getUsername(), refreshToken);
 
-    response.addHeader(env.getProperty("header_string"),
-        env.getProperty("token_prefix") + accessToken);
+    response.addHeader("Authorization",
+        "Bearer " + accessToken);
 
     ResponseService responseService = new ResponseService();
     ObjectMapper mapper = new ObjectMapper();
     try {
       mapper.writeValue(response.getWriter(),
-          responseService.getTokenResponse(env.getProperty("token_prefix") + refreshToken,
-              env.getProperty("token_prefix") + accessToken));
+          responseService.getTokenResponse("Bearer " + refreshToken,
+              "Bearer " + accessToken));
     } catch (IOException ex) {
       throw new RuntimeException(ex);
     }

--- a/src/main/java/com/snacks/demo/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/snacks/demo/jwt/JwtAuthorizationFilter.java
@@ -43,7 +43,7 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
       FilterChain chain) throws IOException, ServletException {
 
     String servletPath = request.getServletPath();
-    String header = request.getHeader(env.getProperty("header_string"));
+    String header = request.getHeader("Authorization");
 
     //로그인, 리프레시 요청이라면 토큰 검사 안함
     if (servletPath.equals("/auth/login") || servletPath.equals("/auth/refresh")
@@ -52,7 +52,7 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
     }
 
     //토큰 값이 없거나 정상적이지 않으면?
-    else if (header == null || !header.startsWith(env.getProperty("token_prefix"))) {
+    else if (header == null || !header.startsWith("Bearer ")) {
       response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);
       response.setCharacterEncoding("UTF-8");
@@ -66,11 +66,11 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
       }
     } else {
       try {
-        String token = request.getHeader(env.getProperty("header_string"))
-            .replace(env.getProperty("token_prefix"), "");
+        String token = request.getHeader("Authorization")
+            .replace("Bearer ", "");
 
         //access token 검증
-        JWTVerifier jwtVerifier = JWT.require(Algorithm.HMAC512(env.getProperty("secret"))).build();
+        JWTVerifier jwtVerifier = JWT.require(Algorithm.HMAC512(env.getProperty("SECRET_SALT"))).build();
         DecodedJWT decodedJWT = jwtVerifier.verify(token);
 
         //authetication 객체 생성


### PR DESCRIPTION
- Authorization 헤더와 Bearer는 관용적인 부분이라 꼭 환경변수를 사용팔 필요는 없는 것 같아서 문자열로 사용.
- 가독성을 위해 사용되는 환경변수 이름 변경.