### PR TITLE
fix: 자체로그인과 oauth2로그인 충돌 수정

### DIFF
--- a/src/main/java/com/snacks/backend/config/SecurityConfig.java
+++ b/src/main/java/com/snacks/backend/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         .and()
         .addFilter(corsConfig.corsFilter())
         .addFilter(new JwtAuthenticationFilter(authenticationManager(), redisService, jwtProvider))
-        .addFilter(new JwtAuthorizationFilter(authenticationManager(), authRepository))
+        .addFilter(new JwtAuthorizationFilter(authenticationManager(), authRepository, jwtProvider))
         .authorizeRequests()
         .antMatchers("/users/**").authenticated()
         .anyRequest().permitAll().and();

--- a/src/main/java/com/snacks/backend/controller/AuthController.java
+++ b/src/main/java/com/snacks/backend/controller/AuthController.java
@@ -86,7 +86,7 @@ public class AuthController {
       String provider = jwtProvider.getProvider(refreshtoken);
       String email = jwtProvider.getEmail(refreshtoken);
 
-      if (provider == "local") {
+      if (provider.equals("local")) {
         Optional<User> user = authRepository.findByEmailAndProvider(email, "local");
         Long id = user.get().getId();
         String value = redisService.getValues(id.toString());

--- a/src/main/java/com/snacks/backend/controller/AuthController.java
+++ b/src/main/java/com/snacks/backend/controller/AuthController.java
@@ -77,9 +77,10 @@ public class AuthController {
             .body(responseService.errorResponse("잘못된 JWT 토큰입니다."));
       }
 
+      String provider = jwtProvider.getProvider(refreshtoken);
 
 
-      String accessToken = jwtProvider.createToken(jwtProvider.getEmail(refreshtoken), "access");
+      String accessToken = jwtProvider.createToken(jwtProvider.getEmail(refreshtoken), "access", provider);
 
       response.addHeader(env.getProperty("access_token"),
           env.getProperty("token_prefix") + accessToken);

--- a/src/main/java/com/snacks/backend/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/snacks/backend/jwt/JwtAuthenticationFilter.java
@@ -86,8 +86,8 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     String refreshToken = jwtProvider.createToken(customUserDetails.getUsername(), "refresh", "local");
     String accessToken = jwtProvider.createToken(customUserDetails.getUsername(), "access", "local");
 
-    redisService.setValues(customUserDetails.getUsername(), refreshToken);
-
+    //redisService.setValues(customUserDetails.getUsername(), refreshToken);
+    redisService.setValues(customUserDetails.getUser().getId().toString(), refreshToken);
     response.addHeader("Authorization",
         "Bearer " + accessToken);
 

--- a/src/main/java/com/snacks/backend/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/snacks/backend/jwt/JwtAuthenticationFilter.java
@@ -83,8 +83,8 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
     CustomUserDetails customUserDetails = (CustomUserDetails) authResult.getPrincipal();
 
-    String refreshToken = jwtProvider.createToken(customUserDetails.getUsername(), "refresh");
-    String accessToken = jwtProvider.createToken(customUserDetails.getUsername(), "access");
+    String refreshToken = jwtProvider.createToken(customUserDetails.getUsername(), "refresh", "local");
+    String accessToken = jwtProvider.createToken(customUserDetails.getUsername(), "access", "local");
 
     redisService.setValues(customUserDetails.getUsername(), refreshToken);
 

--- a/src/main/java/com/snacks/backend/jwt/JwtProvider.java
+++ b/src/main/java/com/snacks/backend/jwt/JwtProvider.java
@@ -20,7 +20,7 @@ public class JwtProvider {
   @Autowired
   RedisService redisService;
 
-  public String createToken(String subject, String type)
+  public String createToken(String subject, String type, String provider)
   {
     String expr;
     if (type == "refresh")
@@ -32,6 +32,7 @@ public class JwtProvider {
         .withSubject(subject)
         .withExpiresAt(new Date(System.currentTimeMillis() + Long.parseLong(expr)))
         .withClaim("email", subject)
+         .withClaim("provider", provider)
         .sign(Algorithm.HMAC512(env.getProperty("SECRET_SALT")));
   }
 
@@ -49,7 +50,7 @@ public class JwtProvider {
 
   public DecodedJWT getdecodedJwt(String token)
   {
-    JWTVerifier jwtVerifier = JWT.require(Algorithm.HMAC512(env.getProperty("secret"))).build();
+    JWTVerifier jwtVerifier = JWT.require(Algorithm.HMAC512(env.getProperty("SECRET_SALT"))).build();
     return jwtVerifier.verify(token);
 
   }
@@ -57,5 +58,11 @@ public class JwtProvider {
   {
     DecodedJWT decodedJWT = getdecodedJwt(token);
     return decodedJWT.getSubject();
+  }
+
+  public String getProvider(String token)
+  {
+    DecodedJWT decodedJWT = getdecodedJwt(token);
+    return decodedJWT.getClaim("provider").asString();
   }
 }

--- a/src/main/java/com/snacks/backend/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/snacks/backend/oauth/CustomOAuth2UserService.java
@@ -62,7 +62,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
 
   private User saveOrUpdate(OAuthAttributes attributes){
-    User user = authRepository.findByEmail(attributes.getEmail())
+    User user = authRepository.findByEmailAndProvider(attributes.getEmail(), "google")
         .map(entity -> entity.update(attributes.getName(), attributes.getPicture()))
         .orElse(attributes.toEntity());
     return authRepository.save(user);

--- a/src/main/java/com/snacks/backend/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/snacks/backend/oauth/OAuth2SuccessHandler.java
@@ -25,8 +25,8 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     DefaultOAuth2User defaultOAuth2User = (DefaultOAuth2User) authentication.getPrincipal();
     String email = defaultOAuth2User.getAttributes().get("email").toString();
 
-    String refreshToken = jwtProvider.createToken(email, "refresh");
-    String accessToken = jwtProvider.createToken(email, "access");
+    String refreshToken = jwtProvider.createToken(email, "refresh", "google");
+    String accessToken = jwtProvider.createToken(email, "access", "google");
 
     redisService.setValues(authentication.getName(), refreshToken);
 

--- a/src/main/java/com/snacks/backend/service/AuthService.java
+++ b/src/main/java/com/snacks/backend/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.snacks.backend.service;
 
+import com.snacks.backend.dto.Role;
 import com.snacks.backend.dto.UserDto;
 import com.snacks.backend.entity.User;
 import com.snacks.backend.repository.AuthRepository;
@@ -32,8 +33,10 @@ public class AuthService {
     User user = new User();
     user.setEmail(userDto.getEmail());
     user.setPassword(passwordEncoder.encode(userDto.getPassword()));
+    user.setRole(Role.USER);
+    user.setProvider("local");
 
-    Optional<User> existedUser = authRepository.findByEmail(user.getEmail());
+    Optional<User> existedUser = authRepository.findByEmailAndProvider(user.getEmail(), "local");
 
     if (existedUser.isPresent()) {
       return ResponseEntity.status(HttpStatus.CONFLICT)


### PR DESCRIPTION
# Pull request 설명
- oauth2로 로그인한 이메일 주소로도 자체 회원가입이 가능하도록 수정
- JwtProvider의 오타로 인한 버그 수정
- redis에 자체로그인은 key를 id값으로, oauth2는 이메일 값으로 저장되도록 변경 (구분을 위함)
<img width="1546" alt="같은이메일 등록" src="https://user-images.githubusercontent.com/57864944/206998503-90fc6a5b-1983-46ef-986e-8a25f1654826.png">

# Test 방법
postman으로 테스트