### PR TITLE
feat: 유저 위젯목록 반환

### DIFF
--- a/src/main/java/com/snacks/backend/config/SecurityConfig.java
+++ b/src/main/java/com/snacks/backend/config/SecurityConfig.java
@@ -50,7 +50,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         .addFilter(new JwtAuthenticationFilter(authenticationManager(), redisService, jwtProvider))
         .addFilter(new JwtAuthorizationFilter(authenticationManager(), authRepository, jwtProvider))
         .authorizeRequests()
-        .antMatchers("/users/**").authenticated()
+       // .antMatchers("/users/**").authenticated()
         .anyRequest().permitAll().and();
 
 

--- a/src/main/java/com/snacks/backend/controller/UserController.java
+++ b/src/main/java/com/snacks/backend/controller/UserController.java
@@ -1,14 +1,21 @@
 package com.snacks.backend.controller;
 
 import com.snacks.backend.dto.UserDto;
+import com.snacks.backend.dto.UserWidgetDto;
+import com.snacks.backend.dto.WidgetDto;
+import com.snacks.backend.response.CommonResponse;
+import com.snacks.backend.response.ListResponse;
 import com.snacks.backend.response.ResponseService;
 import com.snacks.backend.service.AuthService;
+import com.snacks.backend.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,8 +25,27 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/users")
 public class UserController {
 
+  @Autowired
+  UserService userService;
+
   @GetMapping("/test")
   public String test(){
     return "/users/test fin";
   }
+
+  @GetMapping("/{email}/widgets")
+  public UserWidgetDto[] getUserWidget(@PathVariable String email) {
+    return (userService.getUserWidget(email));
+  }
+
+  /*
+  @PatchMapping("/{email}/widgets")
+  public CommonResponse patchUserWidget(@PathVariable String email, @RequestBody UserWidgetDto[] userWidgetDtos) {
+    return (userService.patchUserWidget(email, userWidgetDtos));
+  }
+
+  @PostMapping("/widets")
+  public CommonResponse PostWidget(@RequestBody WidgetDto[] widgetDtos) {
+    return (userService.postWidget(widgetDtos));
+  }*/
 }

--- a/src/main/java/com/snacks/backend/dto/PosDto.java
+++ b/src/main/java/com/snacks/backend/dto/PosDto.java
@@ -1,0 +1,15 @@
+package com.snacks.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PosDto {
+  private Integer x;
+  private Integer y;
+}

--- a/src/main/java/com/snacks/backend/dto/SizeDto.java
+++ b/src/main/java/com/snacks/backend/dto/SizeDto.java
@@ -1,0 +1,15 @@
+package com.snacks.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SizeDto {
+  private Integer w;
+  private  Integer h;
+}

--- a/src/main/java/com/snacks/backend/dto/UserWidgetDto.java
+++ b/src/main/java/com/snacks/backend/dto/UserWidgetDto.java
@@ -1,0 +1,17 @@
+package com.snacks.backend.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+;
+@Getter
+@Setter
+public class UserWidgetDto {
+  private Long duuid;
+  private String name;
+  private PosDto pos;
+  private SizeDto size;
+  private String data;
+}
+
+

--- a/src/main/java/com/snacks/backend/dto/WidgetDto.java
+++ b/src/main/java/com/snacks/backend/dto/WidgetDto.java
@@ -1,0 +1,5 @@
+package com.snacks.backend.dto;
+
+public class WidgetDto {
+
+}

--- a/src/main/java/com/snacks/backend/entity/UserWidget.java
+++ b/src/main/java/com/snacks/backend/entity/UserWidget.java
@@ -1,0 +1,75 @@
+package com.snacks.backend.entity;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+public class UserWidget implements Serializable {
+
+ // @EmbeddedId
+  //UserWidgetId userWidgetId;
+
+  @Id
+  @Column(name = "id")
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(name = "user_id")
+  private User user;
+
+  @ManyToOne
+  @JoinColumn(name = "widget_id")
+  private Widget widget;
+
+  @Column(name = "title")
+  private String title;
+
+  @Column(name = "x", nullable = false)
+  private int x;
+
+  @Column(name = "y", nullable = false)
+  private int y;
+
+  @Column(name = "w", nullable = false)
+  private int w;
+
+  @Column(name = "h", nullable = false)
+  private int h;
+
+  @Column(name = "data")
+  private String data;
+
+  @Column(name = "updated_at")
+  private LocalDateTime updated_at;
+
+
+
+  //public UserWidget(UserWidgetId userWidgetId) {
+   // this.userWidgetId = userWidgetId;
+  //}
+
+  public Long getUserId() {
+    return user.getId();
+  }
+
+  public Long getWidgetId() {
+    return widget.getId();
+  }
+
+}

--- a/src/main/java/com/snacks/backend/entity/UserWidgetId.java
+++ b/src/main/java/com/snacks/backend/entity/UserWidgetId.java
@@ -1,0 +1,19 @@
+package com.snacks.backend.entity;
+
+import java.io.Serializable;
+import javax.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Embeddable
+public class UserWidgetId implements Serializable {
+  private Long userId;
+  private Long widgetId;
+
+}

--- a/src/main/java/com/snacks/backend/entity/Widget.java
+++ b/src/main/java/com/snacks/backend/entity/Widget.java
@@ -1,0 +1,32 @@
+package com.snacks.backend.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+public class Widget {
+  @Id
+  @Column(name = "widget_id")
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "name", nullable = false)
+  private String name;
+
+  @Column
+  private String description;
+
+  @Column
+  private String image;
+
+  @Column
+  private String data;
+
+}

--- a/src/main/java/com/snacks/backend/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/snacks/backend/jwt/JwtAuthorizationFilter.java
@@ -50,7 +50,7 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
 
     //로그인, 리프레시 요청이라면 토큰 검사 안함
     if (servletPath.equals("/auth/login") || servletPath.equals("/auth/refresh")
-        || servletPath.equals("/auth") || servletPath.equals("/auth/google")) {
+        || servletPath.equals("/auth") || servletPath.equals("/auth/google") || servletPath.equals("/users/test1@test.com/widgets")) {
       chain.doFilter(request, response);
     }
 

--- a/src/main/java/com/snacks/backend/repository/UserWidgetRepository.java
+++ b/src/main/java/com/snacks/backend/repository/UserWidgetRepository.java
@@ -1,0 +1,16 @@
+package com.snacks.backend.repository;
+
+import com.snacks.backend.entity.UserWidget;
+import com.snacks.backend.entity.UserWidgetId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserWidgetRepository extends JpaRepository<UserWidget, UserWidgetId> {
+  UserWidget save(UserWidget userWidget);
+
+  @Query(value = "SELECT * FROM USER_WIDGET WHERE USER_ID =?1", nativeQuery = true)
+  UserWidget[] findWidgets(Long id);
+
+}

--- a/src/main/java/com/snacks/backend/repository/WidgetRepository.java
+++ b/src/main/java/com/snacks/backend/repository/WidgetRepository.java
@@ -1,0 +1,20 @@
+package com.snacks.backend.repository;
+
+import com.snacks.backend.entity.Widget;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WidgetRepository extends JpaRepository<Widget, Long> {
+  List<Widget> findAll();
+
+  Widget save(Widget widget);
+
+  @Query(value = "SELECT * FROM WIDGET WHERE NAME = ?1", nativeQuery = true)
+  Widget findByName(String name);
+
+  @Query(value = "SELECT * FROM WIDGET WHERE WIDGET_ID = ?1", nativeQuery = true)
+  Widget findByWidgetId(Long id);
+}

--- a/src/main/java/com/snacks/backend/service/UserService.java
+++ b/src/main/java/com/snacks/backend/service/UserService.java
@@ -1,0 +1,84 @@
+package com.snacks.backend.service;
+
+import com.snacks.backend.dto.PosDto;
+import com.snacks.backend.dto.SizeDto;
+import com.snacks.backend.dto.UserWidgetDto;
+import com.snacks.backend.entity.User;
+import com.snacks.backend.entity.UserWidget;
+import com.snacks.backend.entity.Widget;
+import com.snacks.backend.repository.AuthRepository;
+import com.snacks.backend.repository.UserWidgetRepository;
+import com.snacks.backend.repository.WidgetRepository;
+import com.snacks.backend.response.ConstantResponse;
+import com.snacks.backend.response.ResponseService;
+import java.util.Optional;
+import java.util.Vector;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+  @Autowired
+  AuthRepository authRepository;
+
+  @Autowired
+  ResponseService responseService;
+
+  @Autowired
+  WidgetRepository widgetRepository;
+
+  @Autowired
+  UserWidgetRepository userWidgetRepository;
+
+
+  public UserService(AuthRepository authRepository, ResponseService responseService, WidgetRepository widgetRepository, UserWidgetRepository userWidgetRepository) {
+    this.authRepository = authRepository;
+    this.responseService = responseService;
+    this.widgetRepository = widgetRepository;
+    this.userWidgetRepository = userWidgetRepository;
+  }
+  public UserWidgetDto[] getUserWidget(String email){
+    Optional<User> user = authRepository.findByEmail(email);
+
+    /*if (!user.isPresent()) {
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+          .body(responseService.errorResponse(ConstantResponse.EMAIL_NOT_FOUND));
+    }*/
+    UserWidget[] userWidgets = userWidgetRepository.findWidgets(user.get().getId());
+
+    //if (userWidgets == null) null이면??? 어떡하지 그냥 빈칸 아닌가
+
+    Vector<UserWidgetDto> vector = new Vector<>();
+
+    for(UserWidget userWidget : userWidgets) {
+      UserWidgetDto userWidgetDto = new UserWidgetDto();
+      Widget widget = widgetRepository.findByWidgetId(userWidget.getWidgetId());
+
+      /*if (widget == null) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(responseService.errorResponse("존재하지 않는 위젯입니다.")); //log 저기다 정리하기 하는김에 다른 파일도
+      }*/
+
+      userWidgetDto.setDuuid(userWidget.getId());
+      userWidgetDto.setName(widget.getName());
+      userWidgetDto.setPos(new PosDto(userWidget.getX(), userWidget.getW()));
+      userWidgetDto.setSize(new SizeDto(userWidget.getW(), userWidget.getH()));
+      userWidgetDto.setData(userWidget.getData());
+      vector.add(userWidgetDto);
+    }
+
+    UserWidgetDto[] widgetDtos = new UserWidgetDto[vector.size()];
+    for (int i = 0; i < vector.size(); i++) {
+      widgetDtos[i] = vector.get(i);
+    }
+
+    //return ResponseEntity.status(HttpStatus.OK)
+    //    .body(responseService.getListResponse(widgetDtos));
+    return widgetDtos;
+
+
+
+  }
+}


### PR DESCRIPTION
# Pull Request 설명

- JWT 적용 안하는 버전의 유저 위젯 목록 반환 api 구현
- GET /users/{email}/widgets

# Test 방법
- 현재 JWT를 고려하지않고 api를 작성했기에 GET /users/test1@test.com/widgets만 연결 가능
- 테스트 전에 미리 db 테이블에 값을 넣어놔야함

`INSERT INTO widget (name) VALUES ('memo');`
`INSERT INTO widget (name) VALUES ('ascii');`
`INSERT INTO widget (name) VALUES ('weather');`
`INSERT INTO widget (name) VALUES ('todo');`
`INSERT INTO widget (name) VALUES ('timer');`

`INSERT INTO user (email) VALUES ('test1@test.com');`

`INSERT INTO user_widget (user_id, widget_id, x, y, w, h) VALUES (1, 3, 2, 1, 2, 2);`
`INSERT INTO user_widget (user_id, widget_id, x, y, w, h) VALUES (1, 1, 2, 0, 1, 1);`
`INSERT INTO user_widget (user_id, widget_id, x,y,w,h) VALUES (1, 3, 3, 0, 1, 1);`
`INSERT INTO user_widget (user_id, widget_id, x,y,w,h) VALUES (1, 2, 4, 1, 1, 1);`
`INSERT INTO user_widget (user_id, widget_id, x,y,w,h) VALUES (1, 4, 4, 2, 1, 1);`
`INSERT INTO user_widget (user_id, widget_id, x,y,w,h) VALUES (1, 1, 0, 2, 1, 1);`
`INSERT INTO user_widget (user_id, widget_id, x,y,w,h) VALUES (1, 2, 4, 1, 1, 1);`
`INSERT INTO user_widget (user_id, widget_id, x,y,w,h) VALUES (1, 5, 1, 2, 1, 1);`