### PR TITLE
feat: 유저 위젯 삭제

### DIFF
--- a/src/main/java/com/snacks/backend/controller/UserController.java
+++ b/src/main/java/com/snacks/backend/controller/UserController.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -42,5 +43,10 @@ public class UserController {
   @PutMapping("/{email}/widgets")
   public ResponseEntity putUserWidget(@PathVariable String email, @RequestBody UserWidgetDto[] userWidgetDtos) {
     return (userService.putUserWidget(email, userWidgetDtos));
+  }
+
+  @DeleteMapping("/{email}/widgets/{duuid}")
+  public ResponseEntity deleteUserWidget(@PathVariable String email, @PathVariable String duuid) {
+    return (userService.deleteUserWidget(email, duuid));
   }
 }

--- a/src/main/java/com/snacks/backend/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/snacks/backend/jwt/JwtAuthorizationFilter.java
@@ -50,7 +50,8 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
 
     //로그인, 리프레시 요청이라면 토큰 검사 안함
     if (servletPath.equals("/auth/login") || servletPath.equals("/auth/refresh")
-        || servletPath.equals("/auth") || servletPath.equals("/auth/google") || servletPath.equals("/users/test1@test.com/widgets")) {
+        || servletPath.equals("/auth") || servletPath.equals("/auth/google") || servletPath.equals("/users/test1@test.com/widgets")
+  || servletPath.equals("/users/test1@test.com/widgets/3")) {
       chain.doFilter(request, response);
     }
 

--- a/src/main/java/com/snacks/backend/repository/UserWidgetRepository.java
+++ b/src/main/java/com/snacks/backend/repository/UserWidgetRepository.java
@@ -13,4 +13,7 @@ public interface UserWidgetRepository extends JpaRepository<UserWidget, UserWidg
   @Query(value = "SELECT * FROM USER_WIDGET WHERE USER_ID =?1", nativeQuery = true)
   UserWidget[] findWidgets(Long id);
 
+  @Query(value = "SELECT * FROM USER_WIDGET WHERE ID = ?1", nativeQuery = true)
+  UserWidget findById(Long id);
+
 }

--- a/src/main/java/com/snacks/backend/service/UserService.java
+++ b/src/main/java/com/snacks/backend/service/UserService.java
@@ -106,4 +106,14 @@ public class UserService {
     return ResponseEntity.status(HttpStatus.CREATED).
         body(responseService.getCommonResponse());
   }
+
+  public ResponseEntity deleteUserWidget(String email, String duuid) {
+
+    Long id = Long.parseLong(duuid);
+    UserWidget userWidget = userWidgetRepository.findById(id);
+    userWidgetRepository.delete(userWidget);
+
+    return ResponseEntity.status(HttpStatus.OK).
+        body(responseService.getCommonResponse());
+  }
 }


### PR DESCRIPTION
# Pull Request 설명

- JWT 적용 안하는 버전의 유저 대시보드의 특정 위젯 삭제
- DELETE /users/{email}/widgets/{duuid}

# Test 방법

현재 JWT를 고려하지않고 api를 작성했기에 DELETE /users/test1@test.com/widgets/3만 연결 가능
테스트 전에 미리 db 테이블에 값을 넣어놔야함
`INSERT INTO widget (name) VALUES ('memo');`
`INSERT INTO widget (name) VALUES ('ascii');`
`INSERT INTO widget (name) VALUES ('weather');`
`INSERT INTO widget (name) VALUES ('todo');`
`INSERT INTO widget (name) VALUES ('timer');`

`INSERT INTO user (email) VALUES ('test1@test.com');`

`INSERT INTO user_widget (user_id, widget_id, x, y, w, h) VALUES (1, 3, 2, 1, 2, 2);`
`INSERT INTO user_widget (user_id, widget_id, x, y, w, h) VALUES (1, 1, 2, 1, 1, 1);`
`INSERT INTO user_widget (user_id, widget_id, x,y,w,h) VALUES (1, 3, 3, 1, 1, 1);`
`INSERT INTO user_widget (user_id, widget_id, x,y,w,h) VALUES (1, 2, 4, 1, 1, 1);`