### PR TITLE
fix: 유저 위젯 업데이트

### DIFF
--- a/src/main/java/com/snacks/backend/controller/UserController.java
+++ b/src/main/java/com/snacks/backend/controller/UserController.java
@@ -49,4 +49,5 @@ public class UserController {
   public ResponseEntity deleteUserWidget(@PathVariable String email, @PathVariable String duuid) {
     return (userService.deleteUserWidget(email, duuid));
   }
+
 }

--- a/src/main/java/com/snacks/backend/entity/UserWidget.java
+++ b/src/main/java/com/snacks/backend/entity/UserWidget.java
@@ -41,16 +41,16 @@ public class UserWidget implements Serializable {
   private String title;
 
   @Column(name = "x", nullable = false)
-  private int x;
+  private Integer x;
 
   @Column(name = "y", nullable = false)
-  private int y;
+  private Integer y;
 
   @Column(name = "w", nullable = false)
-  private int w;
+  private Integer w;
 
   @Column(name = "h", nullable = false)
-  private int h;
+  private Integer h;
 
   @Column(name = "data")
   private String data;
@@ -76,4 +76,12 @@ public class UserWidget implements Serializable {
     return widget.getId();
   }
 
+
+  public void update(Integer x, Integer y, Integer w, Integer h, String data) {
+    this.x = x;
+    this.y = y;
+    this.w = w;
+    this.h = h;
+    this.data = data;
+  }
 }

--- a/src/main/java/com/snacks/backend/service/UserService.java
+++ b/src/main/java/com/snacks/backend/service/UserService.java
@@ -91,7 +91,6 @@ public class UserService {
 
       UserWidget userWidget = userWidgetRepository.findById(userWidgetDto.getDuuid());
 
-      //updateUserWidget(userWidget);
       userWidget.update(userWidgetDto.getPos().getX(), userWidgetDto.getPos().getY(), userWidgetDto.getSize().getW(), userWidgetDto.getSize().getH(),
           userWidgetDto.getData());
     }

--- a/src/main/java/com/snacks/backend/service/UserService.java
+++ b/src/main/java/com/snacks/backend/service/UserService.java
@@ -110,16 +110,5 @@ public class UserService {
         body(responseService.getCommonResponse());
   }
 
-  @Transactional
-  public void updateUserWidget(UserWidget widget) {
-    UserWidget userWidget = userWidgetRepository.findById(widget.getId());
-
-    userWidget.setX(widget.getX());
-    userWidget.setY(widget.getY());
-    userWidget.setW(widget.getW());
-    userWidget.setH(widget.getH());
-    userWidget.setData(widget.getData());
-
-    userWidgetRepository.save(userWidget);
   }
 }

--- a/src/main/java/com/snacks/backend/service/UserService.java
+++ b/src/main/java/com/snacks/backend/service/UserService.java
@@ -13,6 +13,7 @@ import com.snacks.backend.response.ConstantResponse;
 import com.snacks.backend.response.ResponseService;
 import java.util.Optional;
 import java.util.Vector;
+import javax.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -82,27 +83,19 @@ public class UserService {
 
   }
 
+  @Transactional
   public ResponseEntity putUserWidget(String email, UserWidgetDto[] userWidgetDtos) {
     Optional<User> user = authRepository.findByEmail(email);
 
     for (UserWidgetDto userWidgetDto : userWidgetDtos) {
 
-      Widget widget = widgetRepository.findByName(userWidgetDto.getName());
-      UserWidget userWidget = new UserWidget();
+      UserWidget userWidget = userWidgetRepository.findById(userWidgetDto.getDuuid());
 
-      userWidget.setUser(user.get());
-      userWidget.setWidget(widget);
-      userWidget.setUserId(user.get().getId());
-      userWidget.setWidgetId(widget.getId());
-      userWidget.setTitle(widget.getName());
-      userWidget.setX(userWidgetDto.getPos().getX());
-      userWidget.setY(userWidgetDto.getPos().getY());
-      userWidget.setW(userWidgetDto.getSize().getW());
-      userWidget.setH(userWidgetDto.getSize().getH());
-      userWidget.setData(userWidgetDto.getData());
-
-      userWidgetRepository.save(userWidget);
+      //updateUserWidget(userWidget);
+      userWidget.update(userWidgetDto.getPos().getX(), userWidgetDto.getPos().getY(), userWidgetDto.getSize().getW(), userWidgetDto.getSize().getH(),
+          userWidgetDto.getData());
     }
+
     return ResponseEntity.status(HttpStatus.CREATED).
         body(responseService.getCommonResponse());
   }
@@ -115,5 +108,18 @@ public class UserService {
 
     return ResponseEntity.status(HttpStatus.OK).
         body(responseService.getCommonResponse());
+  }
+
+  @Transactional
+  public void updateUserWidget(UserWidget widget) {
+    UserWidget userWidget = userWidgetRepository.findById(widget.getId());
+
+    userWidget.setX(widget.getX());
+    userWidget.setY(widget.getY());
+    userWidget.setW(widget.getW());
+    userWidget.setH(widget.getH());
+    userWidget.setData(widget.getData());
+
+    userWidgetRepository.save(userWidget);
   }
 }


### PR DESCRIPTION
# Pull Request 설명

- JWT 적용 안하는 버전의 유저 위젯 업데이트 api 구현
- PUT /users/{email}/widgets
- 기존 #19  pr의 API를 POST 기능(위젯 추가)으로 헷갈려 위젯 업데이트 기능으로 정정한 코드

# Test 방법
현재 JWT를 고려하지않고 api를 작성했기에 PUT /users/test1@test.com/widgets만 연결 가능
테스트 전에 미리 db 테이블에 값을 넣어놔야함
`INSERT INTO widget (name) VALUES ('memo');`
`INSERT INTO widget (name) VALUES ('ascii');`
`INSERT INTO widget (name) VALUES ('weather');`
`INSERT INTO widget (name) VALUES ('todo');`
`INSERT INTO widget (name) VALUES ('timer');`

`INSERT INTO user (email) VALUES ('test1@test.com');`


`INSERT INTO user_widget (user_id, widget_id, x, y, w, h) VALUES (1, 3, 2, 1, 2, 2);`
`INSERT INTO user_widget (user_id, widget_id, x, y, w, h) VALUES (1, 1, 2, 1, 1, 1);`
`INSERT INTO user_widget (user_id, widget_id, x,y,w,h) VALUES (1, 3, 3, 1, 1, 1);`
`INSERT INTO user_widget (user_id, widget_id, x,y,w,h) VALUES (1, 2, 4, 1, 1, 1);`