### PR TITLE
fix: 같은 이메일이 등록 되어 있을 시 로그인이 안되는 현상

### DIFF
--- a/src/main/java/com/snacks/backend/jwt/auth/CustomUserDetailsService.java
+++ b/src/main/java/com/snacks/backend/jwt/auth/CustomUserDetailsService.java
@@ -19,7 +19,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
   @Override
   public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-    Optional<User> user = authRepository.findByEmail(email);
+    Optional<User> user = authRepository.findByEmailAndProvider(email, "local");
 
     user.orElseThrow(() -> new UsernameNotFoundException("없는 이메일입니다."));
     return new CustomUserDetails(user.get());


### PR DESCRIPTION
# Pull Request 설명

- oauth2를 통해 구글 로그인을 한 후, 같은 이메일로 로컬 로그인을 시도했을때 로그인이 안되는 현상 수정
- CustomUserDetailsService에서 findByEmail 대신 findByEmailAndProvider 적용

# 테스트 방법
postman으로 테스트

테스트 전에 미리 db에 값을 넣어야 함

`INSERT INTO user (email, provider_type) VALUES ('test1@test.com', 'google');`

이후 `test1@test.com`으로 회원가입 및 로그인 진행
